### PR TITLE
docs: list initial project lead and committers

### DIFF
--- a/COMMITTERS.md
+++ b/COMMITTERS.md
@@ -1,0 +1,12 @@
+# Project Lead and Committers
+
+## Project Lead
+
+Chris Paraiso @cparaiso
+
+## Committers
+
+The committers for this project are those for uPortal itself, documented
+as of this writing in [`COMMITTERS.md` in `Jasig/uPortal`][uportal committers].
+
+[uportal committers]: https://github.com/Jasig/uPortal/blob/master/docs/COMMITTERS.md


### PR DESCRIPTION
This document is used as part of the Apereo uPortal intake process, to move the repo over to uPortal-contrib.